### PR TITLE
New_missing_linked_materials_warning

### DIFF
--- a/thea_IR.py
+++ b/thea_IR.py
@@ -922,16 +922,18 @@ class RENDER_PT_thea_startIR(bpy.types.Operator):
         from TheaForBlender.thea_render_main import checkTheaMaterials
         if(checkTheaMaterials()==False):
             self.report({'ERROR'}, "Please set materials and lights to get proper render")
-            #return {'FINISHED'}
-#        global matExtLink, matNameExt
-#        matExtLink = ""
-#        matNameExt = "TestName"
+            return {'FINISHED'}
+
         from TheaForBlender.thea_render_main import checkTheaExtMat
-#        checkTheaExtMat(matExtLink, matNameExt)
-#        thea_globals.log.debug("*** CheckMaterials = %s ***" % checkTheaExtMat.matNameExt)
-        if (checkTheaExtMat()==False):
-            self.report({'ERROR'}, "Please check linked materials")
-#            thea_globals.log.debug("*** CheckMaterials = %s ***" % matExtLink)
+        checkTheaExtMat()
+        valuesExt = checkTheaExtMat()
+        if (valuesExt[0]==False):
+#            self.report({'ERROR'}, "Please link Material: %s > Object: %s" % (valuesExt[1], valuesExt[2]))
+            missing_Mat = ""
+            for mat in valuesExt[3]:
+                missing_Mat = missing_Mat+"\n"+mat
+            self.report({'ERROR'}, "Please link Material:%s" % missing_Mat)
+#            thea_globals.log.debug("*** CheckMaterials = %s ***" % valuesExt[1])
             return {'FINISHED'}
         if not os.path.isdir(self.exportPath):
             self.report({'ERROR'}, "Please set proper output path before exporting!")


### PR DESCRIPTION
This is added part for the missing linked material feature. Prior when linked materials where there, all you got was a warning. The user needed to find the material by her/his self.

Now when materials are missing it gives the material name and object name in a popup list. Perhaps a new window needs to be created where this is stored.